### PR TITLE
Confirm deletion

### DIFF
--- a/src/parsagon/main.py
+++ b/src/parsagon/main.py
@@ -99,6 +99,9 @@ def main():
         type=str,
         help="the name of the program to run",
     )
+    parser_delete.add_argument(
+        "-y", "--yes", dest="confirm_with_user", action="store_false", help="auto-confirm option"
+    )
     parser_delete.set_defaults(func=delete)
 
     args = parser.parse_args()
@@ -204,7 +207,13 @@ def run(program_name, variables={}, environment="LOCAL", headless=False, verbose
     return globals_locals["output"]
 
 
-def delete(program_name, verbose=False):
+def delete(program_name, verbose=False, confirm_with_user=False):
+    if (
+        confirm_with_user
+        and input(f"Are you sure you want to delete program with name {program_name}? (y/N) ").lower().strip() != "y"
+    ):
+        logger.error("Cancelled operation.")
+        return
     logger.info("Preparing to delete program %s", program_name)
     try:
         pipeline_id = get_pipeline(program_name)["id"]


### PR DESCRIPTION
Tested and working.  Users of the python (non-CLI) interface have an argument available called "confirm_with_user" that is meant for CLI interaction.