### PR TITLE
Autocomplete speedup

### DIFF
--- a/src/parsagon/highlights.js
+++ b/src/parsagon/highlights.js
@@ -326,16 +326,19 @@ function getNumExamples() {
             TARGET_STORED_CLASSNAME
         );
     return exampleElems.length;
-};
+}
 
 function addAutocompletes() {
     const autocompleteElems =
         document.getElementsByClassName(
             AUTOCOMPLETE_CLASSNAME
         );
-    while (autocompleteElems.length) {
-        removeAutocompleteCSS(autocompleteElems[0]);
-    }
+    withDefer((defer) => {
+        while (autocompleteElems.length) {
+            removeAutocompleteCSS(autocompleteElems[0], defer);
+        }
+    });
+
 
     const exampleElems =
         document.getElementsByClassName(
@@ -347,13 +350,15 @@ function addAutocompletes() {
             document.querySelectorAll(
                 cssSelector
             );
-        for (const elem of similarElems) {
-            if (elem.classList.contains(TARGET_STORED_CLASSNAME)) {
-                continue;
+        withDefer((defer) => {
+            for (const elem of similarElems) {
+                if (elem.classList.contains(TARGET_STORED_CLASSNAME)) {
+                    continue;
+                }
+                makeVisible(elem, defer);
+                addAutocompleteCSS(elem, defer);
             }
-            makeVisible(elem);
-            addAutocompleteCSS(elem);
-        }
+        });
     }
 }
 

--- a/src/parsagon/highlights.js
+++ b/src/parsagon/highlights.js
@@ -82,7 +82,7 @@ const CSS = `
 }
 `;
 
-function staticToRelativePositioning(element, defer=immediateDeferFn) {
+function staticToRelativePositioning(element, defer=defaultDefer) {
     if (
         window.getComputedStyle(element)
             .position === 'static'
@@ -156,7 +156,7 @@ function withDefer(fn) {
     }
 }
 
-const immediateDeferFn = (manipulationFn, element, ...otherArgs) => {
+const defaultDefer = (manipulationFn, element, ...otherArgs) => {
     manipulationFn(element, ...otherArgs);
 }
 
@@ -206,7 +206,7 @@ function hasValidData(element, dataType) {
     return true;
 }
 
-function makeVisible(element, defer=immediateDeferFn) {
+function makeVisible(element, defer=defaultDefer) {
     const rects = element.getClientRects();
     if (rects.length) {
         const rect = rects[0];
@@ -267,7 +267,7 @@ function getSimilar(elements) {
     }
 }
 
-function addMouseVisitedCSS(element, defer=immediateDeferFn) {
+function addMouseVisitedCSS(element, defer=defaultDefer) {
     if (
         !element.classList.contains(TARGET_STORED_CLASSNAME) &&
         !element.classList.contains(AUTOCOMPLETE_CLASSNAME)
@@ -278,7 +278,7 @@ function addMouseVisitedCSS(element, defer=immediateDeferFn) {
     defer(addClass, element, MOUSE_VISITED_CLASSNAME);
 }
 
-function removeMouseVisitedCSS(element, defer=immediateDeferFn) {
+function removeMouseVisitedCSS(element, defer=defaultDefer) {
     if (
         !element.classList.contains(TARGET_STORED_CLASSNAME) &&
         !element.classList.contains(AUTOCOMPLETE_CLASSNAME)
@@ -288,13 +288,13 @@ function removeMouseVisitedCSS(element, defer=immediateDeferFn) {
     defer(removeClass, element, MOUSE_VISITED_CLASSNAME);
 }
 
-function addTargetStoredCSS(element, defer=immediateDeferFn) {
+function addTargetStoredCSS(element, defer=defaultDefer) {
     defer(addTargetStoredOutline, element);
     staticToRelativePositioning(element, defer);
     defer(addClass, element, TARGET_STORED_CLASSNAME);
 }
 
-function removeTargetStoredCSS(element, defer=immediateDeferFn) {
+function removeTargetStoredCSS(element, defer=defaultDefer) {
     defer(removeOutline, element);
     defer(removeClass, element, TARGET_STORED_CLASSNAME);
     if (element.classList.contains(AUTOCOMPLETE_CLASSNAME)) {
@@ -304,7 +304,7 @@ function removeTargetStoredCSS(element, defer=immediateDeferFn) {
     }
 }
 
-function addAutocompleteCSS(element, defer=immediateDeferFn) {
+function addAutocompleteCSS(element, defer=defaultDefer) {
     if (!element.classList.contains(TARGET_STORED_CLASSNAME)) {
         defer(addAutocompleteOutline, element);
         staticToRelativePositioning(element, defer);
@@ -312,7 +312,7 @@ function addAutocompleteCSS(element, defer=immediateDeferFn) {
     defer(addClass, element, AUTOCOMPLETE_CLASSNAME);
 }
 
-function removeAutocompleteCSS(element, defer=immediateDeferFn) {
+function removeAutocompleteCSS(element, defer=defaultDefer) {
     defer(removeOutline, element);
     defer(removeClass, element, AUTOCOMPLETE_CLASSNAME);
     if (element.classList.contains(MOUSE_VISITED_CLASSNAME)) {

--- a/src/parsagon/highlights.js
+++ b/src/parsagon/highlights.js
@@ -130,7 +130,13 @@ function removeClass(element, className) {
     element.classList.remove(className);
 }
 
-function withDefer(fn) {
+/**
+ * Provide a callback to be immediately executed, which will be passed a "defer" function as an argument.
+ * Within the callback you may call `defer(fn, arg1, arg2, ...)` to defer the execution of `fn(arg1, arg2, ...)` until after the callback finishes running.
+ * This way, write operations to the DOM can be bulked together for performance.
+ * Note: the first argument to any deferred function must be an HTML element.
+ */
+function withDefer(callback) {
 
     // Collect deferred calls in a map of element -> [function, other args]. Assumes that the first argument to the "manipulationFn" is an HTML element.
     const deferredCalls = new Map();
@@ -147,7 +153,7 @@ function withDefer(fn) {
     }
 
     // Execute the function, registering deferred calls
-    fn(defer);
+    callback(defer);
 
     // Execute deferred calls
     for (const [element, calls] of deferredCalls) {

--- a/src/parsagon/highlights.js
+++ b/src/parsagon/highlights.js
@@ -133,26 +133,27 @@ function removeClass(element, className) {
 function withDefer(fn) {
 
     // Collect deferred calls in a map of element -> [function, other args]. Assumes that the first argument to the "manipulationFn" is an HTML element.
-    const deferredCalls = [];
+    const deferredCalls = new Map();
     const defer = (manipulationFn, element, ...otherArgs) => {
         if (typeof manipulationFn !== 'function') {
             throw new Error('First argument must be a function');
         }
-        const newCall = [manipulationFn, element, otherArgs];
-        // if (deferredCalls.has(element)) {
-        //     deferredCalls.get(element).push(newCall);
-        // } else {
-        //     deferredCalls.set(element, [newCall]);
-        // }
-        deferredCalls.push(newCall);
+        const newCall = [manipulationFn, otherArgs];
+        if (deferredCalls.has(element)) {
+            deferredCalls.get(element).push(newCall);
+        } else {
+            deferredCalls.set(element, [newCall]);
+        }
     }
 
     // Execute the function, registering deferred calls
     fn(defer);
 
     // Execute deferred calls
-    for (const [manipulationFn, element, calls] of deferredCalls) {
-        manipulationFn(element, ...calls);
+    for (const [element, calls] of deferredCalls) {
+        for (const [manipulationFn, otherArgs] of calls) {
+            manipulationFn(element, ...otherArgs);
+        }
     }
 }
 


### PR DESCRIPTION
I profiled autocomplete yesterday and found that it was slow because of something called "forced reflows". Basically anytime you mutate a DOM element (e.g. modify the classes of an element to include our autocomplete class), you make it so that the page will be re-laid-out any time you try to read a property again, especially ones relating to width, height, dimensions, etc. Before this PR, we had it so that if there are n auto-complete suggestions, the page is being re-laid-out n times, which was causing those 9 second delays for me on some pages.

I built a tool to avoid this called `withDefer`, which allows bulking of DOM-write operations. From the comment:
```
/**
 * Provide a callback to be immediately executed, which will be passed a "defer" function as an argument.
 * Within the callback you may call `defer(fn, arg1, arg2, ...)` to defer the execution of `fn(arg1, arg2, ...)` until after the callback finishes running.
 * This way, write operations to the DOM can be bulked together for performance.
 * Note: the first argument to any deferred function must be an HTML element.
 */
function withDefer(callback)
```

Example:
```
withDefer((defer) => {
    for (const elem of similarElems) {
        if (elem.classList.contains(TARGET_STORED_CLASSNAME)) {
            continue;
        }
        makeVisible(elem, defer);
        addAutocompleteCSS(elem, defer);
    }
});
```
...and then within `makeVisible`:
```
        if (rect.width * rect.height === 0) {
            defer(setDisplayBlock, element);
        }
```
If instead we were to set the display CSS attribute to `block` immediately without deferring execution, then this mutation would interrupt the batch of read operations and cause the next read operation to require a reflow/re-layout.